### PR TITLE
FIX typo in the Author section

### DIFF
--- a/README_template.md
+++ b/README_template.md
@@ -83,4 +83,4 @@ This application/site was created as a submission to a [DevChallenges](https://d
 ## Author
 
 - Website [your-website.com](https://{your-web-site-link})
-- GitHub [@your-username](https://{github.com/your-usermame})
+- GitHub [@your-username](https://{github.com/your-username})


### PR DESCRIPTION
In the README_template.md, author section the link to the user profile name had a typo error. When you try to match it using the editor you always have to edit it manually instead of replace it automatically. 

**Note:** this typo error appears in almost the 3 first templates of the Web Design Roadmap, so is probably that the typo is spreaded in all templated